### PR TITLE
Fix login payload and rename users endpoint

### DIFF
--- a/src/app/GlobalComponents.ts
+++ b/src/app/GlobalComponents.ts
@@ -7,6 +7,6 @@ export const GlobalComponent = {
 
 
     //users
-    getAllUSers: '/api/v1/manager/users'
+    getAllUsers: '/api/v1/manager/users'
 
 }

--- a/src/app/core/service/rest.service.ts
+++ b/src/app/core/service/rest.service.ts
@@ -17,16 +17,20 @@ export class RestService {
     }
 
     postAuthLogin(data: any): Observable<any> {
-        return this.http.post(GlobalComponent.auth_login, {
-            headers: new HttpHeaders({
-                'Content-Type': 'application/json',
-                Authorization: `Bearer ${sessionStorage.getItem('access_token')}`,
-            }),
-        });
+        return this.http.post(
+            GlobalComponent.auth_login,
+            data,
+            {
+                headers: new HttpHeaders({
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${sessionStorage.getItem('access_token')}`,
+                }),
+            }
+        );
     }
 
     getAllUsers(): Observable<any> {
-        return this.http.get(GlobalComponent.getAllUSers, {
+        return this.http.get(GlobalComponent.getAllUsers, {
             headers: new HttpHeaders({
                 'Content-Type': 'application/json',
                 Authorization: `Bearer ${sessionStorage.getItem('access_token')}`,


### PR DESCRIPTION
## Summary
- pass user data as body in `postAuthLogin`
- supply headers as options
- rename `getAllUSers` constant to `getAllUsers`
- use `GlobalComponent.getAllUsers` in `RestService`

## Testing
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883697f5a90832d9b6960ba82f35f33